### PR TITLE
Guard analytics tracking and normalize layout sizing

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,17 +26,56 @@
   </div>
 </template>
 <script>
-document.documentElement.style.setProperty('--screen-width', window.innerWidth);
+const SCREEN_WIDTH_VARIABLE = '--screen-width';
+const DESKTOP_BREAKPOINT = 900;
+const ADJUSTMENT_FACTOR = 0.12;
+const MIN_WIDTH_PERCENT = 60;
+const MAX_WIDTH_PERCENT = 100;
 
-window.addEventListener('resize', function() {
-  document.documentElement.style.setProperty(
-    '--screen-width',
-    '' + (100 + (900 - window.innerWidth) * 0.12) + '%',
-  );
-  console.log('resize');
-});
+export default {
+  name: 'AppRoot',
+  data() {
+    return {
+      resizeHandler: null,
+    };
+  },
+  mounted() {
+    if (typeof window === 'undefined') {
+      return;
+    }
 
-export default {};
+    this.updateScreenWidth();
+    this.resizeHandler = () => this.updateScreenWidth();
+    window.addEventListener('resize', this.resizeHandler);
+  },
+  beforeDestroy() {
+    if (typeof window === 'undefined' || !this.resizeHandler) {
+      return;
+    }
+
+    window.removeEventListener('resize', this.resizeHandler);
+  },
+  methods: {
+    updateScreenWidth() {
+      if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return;
+      }
+
+      const innerWidth = window.innerWidth;
+      const rawWidth =
+        100 + (DESKTOP_BREAKPOINT - innerWidth) * ADJUSTMENT_FACTOR;
+      const normalizedWidth = Math.min(
+        MAX_WIDTH_PERCENT,
+        Math.max(MIN_WIDTH_PERCENT, rawWidth),
+      );
+
+      document.documentElement.style.setProperty(
+        SCREEN_WIDTH_VARIABLE,
+        `${normalizedWidth}%`,
+      );
+    },
+  },
+};
 </script>
 <style>
 html {

--- a/src/main.js
+++ b/src/main.js
@@ -28,8 +28,15 @@ Vue.filter('capitalize', value => {
 });
 
 router.afterEach(() => {
-  setTimeout(function () {
-    window.dataLayer.push({ event: 'NavigationComplete' });
+  setTimeout(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const { dataLayer } = window;
+    if (Array.isArray(dataLayer)) {
+      dataLayer.push({ event: 'NavigationComplete' });
+    }
   }, 1000);
 });
 


### PR DESCRIPTION
## Summary
- move App layout sizing into lifecycle-managed helper with clamped percentage values
- ensure resize listeners are cleaned up when the root component unmounts
- guard dataLayer pushes so navigation tracking does not throw when Google Tag Manager is unavailable

## Testing
- npm run lint *(fails: vue-cli-service not found with the current npm/node toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68e795dcdd088333809568744a3e7b4e