### PR TITLE
Replace vue-highlight.js with highlight.js 11 directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "core-js": "^3.39.0",
-        "highlight.js": "^9.18.5",
+        "highlight.js": "^11.10.0",
         "html-loader": "^1.3.2",
         "vue": "^2.7.16",
         "vue-gtm": "^2.3.4",
-        "vue-highlight.js": "^3.1.0",
         "vue-meta": "^2.4.0",
         "vue-resource": "^1.5.3",
         "vue-router": "^3.6.5",
@@ -6359,14 +6358,12 @@
       "license": "MIT"
     },
     "node_modules/highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
-      "deprecated": "Support has ended for 9.x series. Upgrade to @latest",
-      "hasInstallScript": true,
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
+      "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hmac-drbg": {
@@ -13839,27 +13836,6 @@
       "dependencies": {
         "url-search-params-polyfill": "^8.1.0"
       }
-    },
-    "node_modules/vue-highlight.js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vue-highlight.js/-/vue-highlight.js-3.1.0.tgz",
-      "integrity": "sha512-i55SERtdV0CYQppGo29iT6NOq+oOenOKVwkLWZRt7bSynbsQoj/e8GJy/5xL1s5OOYObC/CxA39bRadVyPQt1A==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-indent": "^5.0.0",
-        "redent": "^2.0.0",
-        "tslib": "^1.9.3"
-      },
-      "peerDependencies": {
-        "highlight.js": "^9.11.0",
-        "vue": "2"
-      }
-    },
-    "node_modules/vue-highlight.js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
   },
   "dependencies": {
     "core-js": "^3.39.0",
-    "highlight.js": "^9.18.5",
+    "highlight.js": "^11.10.0",
     "html-loader": "^1.3.2",
     "vue": "^2.7.16",
     "vue-gtm": "^2.3.4",
-    "vue-highlight.js": "^3.1.0",
     "vue-meta": "^2.4.0",
     "vue-resource": "^1.5.3",
     "vue-router": "^3.6.5",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" v-highlightjs :class="{ frontpage: $route.path == '/' }">
+  <div id="app" :class="{ frontpage: $route.path == '/' }">
     <div id="nav">
       <nav>
         <router-link to="/">
@@ -21,7 +21,7 @@
       </nav>
     </div>
     <transition name="page">
-      <router-view />
+      <router-view v-highlightjs />
     </transition>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" :class="{ frontpage: $route.path == '/' }">
+  <div id="app" v-highlightjs :class="{ frontpage: $route.path == '/' }">
     <div id="nav">
       <nav>
         <router-link to="/">

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,10 @@ import VueResource from 'vue-resource';
 import VueGtm from 'vue-gtm';
 import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
+import json from 'highlight.js/lib/languages/json';
+import bash from 'highlight.js/lib/languages/bash';
 import xml from 'highlight.js/lib/languages/xml';
+import vue from 'highlight.js/lib/languages/vue';
 
 import 'highlight.js/styles/github.css';
 
@@ -14,8 +17,11 @@ Vue.config.productionTip = false;
 Vue.use(VueResource);
 
 hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('json', json);
+hljs.registerLanguage('bash', bash);
 hljs.registerLanguage('xml', xml);
-hljs.registerLanguage('vue', xml);
+hljs.registerLanguage('html', xml);
+hljs.registerLanguage('vue', vue);
 
 const applyHighlighting = el => {
   if (!el) {
@@ -24,16 +30,24 @@ const applyHighlighting = el => {
 
   const blocks = el.querySelectorAll('pre code');
   blocks.forEach(block => {
+    block.classList.remove('hljs');
+    block.removeAttribute('data-highlighted');
     hljs.highlightElement(block);
+  });
+};
+
+const scheduleHighlighting = el => {
+  Vue.nextTick(() => {
+    applyHighlighting(el);
   });
 };
 
 Vue.directive('highlightjs', {
   inserted(el) {
-    applyHighlighting(el);
+    scheduleHighlighting(el);
   },
   componentUpdated(el) {
-    applyHighlighting(el);
+    scheduleHighlighting(el);
   },
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,6 @@ import javascript from 'highlight.js/lib/languages/javascript';
 import json from 'highlight.js/lib/languages/json';
 import bash from 'highlight.js/lib/languages/bash';
 import xml from 'highlight.js/lib/languages/xml';
-import vue from 'highlight.js/lib/languages/vue';
 
 import 'highlight.js/styles/github.css';
 
@@ -21,7 +20,7 @@ hljs.registerLanguage('json', json);
 hljs.registerLanguage('bash', bash);
 hljs.registerLanguage('xml', xml);
 hljs.registerLanguage('html', xml);
-hljs.registerLanguage('vue', vue);
+hljs.registerLanguage('vue', xml);
 
 const applyHighlighting = el => {
   if (!el) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,9 @@
 import Vue from 'vue';
 import VueResource from 'vue-resource';
 import VueGtm from 'vue-gtm';
-import VueHighlightJS from 'vue-highlight.js';
-
+import hljs from 'highlight.js/lib/core';
 import javascript from 'highlight.js/lib/languages/javascript';
-import vue from 'vue-highlight.js/lib/languages/vue';
+import xml from 'highlight.js/lib/languages/xml';
 
 import 'highlight.js/styles/github.css';
 
@@ -13,13 +12,30 @@ import router from './router';
 
 Vue.config.productionTip = false;
 Vue.use(VueResource);
-// Vue.use(VueHighlightJS, {
-//   // Register only languages that you want
-//   languages: {
-//     javascript,
-//     vue,
-//   },
-// });
+
+hljs.registerLanguage('javascript', javascript);
+hljs.registerLanguage('xml', xml);
+hljs.registerLanguage('vue', xml);
+
+const applyHighlighting = el => {
+  if (!el) {
+    return;
+  }
+
+  const blocks = el.querySelectorAll('pre code');
+  blocks.forEach(block => {
+    hljs.highlightElement(block);
+  });
+};
+
+Vue.directive('highlightjs', {
+  inserted(el) {
+    applyHighlighting(el);
+  },
+  componentUpdated(el) {
+    applyHighlighting(el);
+  },
+});
 
 Vue.filter('capitalize', value => {
   if (!value) return '';


### PR DESCRIPTION
## Summary
- bump highlight.js to v11 and drop the deprecated vue-highlight.js dependency
- add a lightweight global directive to highlight code blocks with the updated library
- attach the highlighter directive to the app shell so markdown imports continue to render highlighted code

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68f1f6fdd2c08333a3ec37ac57a6fa32