### PR TITLE
Integrate PostHog analytics tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "core-js": "^3.39.0",
         "highlight.js": "^9.18.5",
         "html-loader": "^1.3.2",
+        "posthog-js": "^1.181.0",
         "vue": "^2.7.16",
         "vue-gtm": "^2.3.4",
         "vue-highlight.js": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "core-js": "^3.39.0",
     "highlight.js": "^9.18.5",
     "html-loader": "^1.3.2",
+    "posthog-js": "^1.181.0",
     "vue": "^2.7.16",
     "vue-gtm": "^2.3.4",
     "vue-highlight.js": "^3.1.0",

--- a/src/composables/usePostHog.js
+++ b/src/composables/usePostHog.js
@@ -1,0 +1,20 @@
+import posthog from 'posthog-js';
+
+let isInitialized = false;
+
+export function usePostHog() {
+  if (typeof window === 'undefined') {
+    return { posthog: null };
+  }
+
+  if (!isInitialized) {
+    posthog.init('phc_yoHWrDfCMhBwLFbT6ukKibtPq7w9F53EISZWtaKhOHJ', {
+      api_host: 'https://eu.i.posthog.com',
+      defaults: '2025-05-24',
+      person_profiles: 'identified_only',
+    });
+    isInitialized = true;
+  }
+
+  return { posthog };
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import VueMeta from 'vue-meta';
 import routes from '@/router/routes';
+import { usePostHog } from '@/composables/usePostHog';
 /* eslint-disable */
 
 Vue.use(VueRouter);
@@ -12,5 +13,21 @@ const router = new VueRouter({
   base: process.env.BASE_URL,
   routes,
 });
+
+const { posthog } = usePostHog();
+
+if (posthog) {
+  router.afterEach((to) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    posthog.capture('$pageview', {
+      $current_url: window.location.href,
+      $pathname: to.fullPath,
+      $title: document.title,
+    });
+  });
+}
 
 export default router;


### PR DESCRIPTION
## Summary
- add the posthog-js dependency and guard the composable so initialization runs only in the browser
- initialize PostHog from the router and capture page view events after each navigation

## Testing
- npm install posthog-js *(fails with 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68f2191abee88333ac301b3311ddb91e